### PR TITLE
Add ci and release support for moodle 4.0+

### DIFF
--- a/.github/workflows/group-40-plus-ci.yml
+++ b/.github/workflows/group-40-plus-ci.yml
@@ -1,0 +1,67 @@
+name: Moodle plugin CI group for Moodle 4.0+
+
+on:
+  workflow_call:
+    inputs:
+      extra_plugin_runners:
+        type: string
+      disable_behat:
+        type: boolean
+      disable_phplint:
+        type: boolean
+      disable_phpunit:
+        type: boolean
+      disable_grunt:
+        type: boolean
+
+jobs:
+  setup:
+    name: 4.0+
+    env:
+      IGNORE_PATHS: tests/fixtures
+    runs-on: 'ubuntu-latest'
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 5432:5432
+
+      mariadb:
+        image: mariadb:10.5
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ['mariadb', 'pgsql']
+        moodle-branch: ['master']
+        node: ['14.15']
+        php: ['7.3']
+
+    steps:
+      - name: Run plugin setup
+        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        with:
+          extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
+          disable_behat: ${{ inputs.disable_behat }}
+          disable_phplint: ${{ inputs.disable_phplint }}
+          disable_phpunit: ${{ inputs.disable_phpunit }}
+          disable_grunt: ${{ inputs.disable_grunt }}

--- a/.github/workflows/group-40-plus-release.yml
+++ b/.github/workflows/group-40-plus-release.yml
@@ -1,0 +1,74 @@
+#
+# Whenever version.php is changed, add the latest version
+# to the Moodle Plugins directory at https://moodle.org/plugins
+#
+# revision: 2021121500
+#
+name: Releasing plugin group for Moodle 4.0+ in the Plugins directory
+
+on:
+  workflow_call:
+    inputs:
+      plugin_name:
+        required: true
+        type: string
+      extra_plugin_runners:
+        type: string
+      disable_behat:
+        type: boolean
+      disable_phplint:
+        type: boolean
+      disable_phpunit:
+        type: boolean
+      disable_grunt:
+        type: boolean
+    secrets:
+      moodle_org_token:
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ['pgsql']
+        moodle-branch: ['master']
+        node: ['14.15']
+        php: ['7.3']
+
+    steps:
+      - name: Run plugin setup
+        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        with:
+          extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
+          disable_behat: ${{ inputs.disable_behat }}
+          disable_phplint: ${{ inputs.disable_phplint }}
+          disable_phpunit: ${{ inputs.disable_phpunit }}
+          disable_grunt: ${{ inputs.disable_grunt }}
+
+      - name: Run plugin release
+        if: ${{ matrix.moodle-branch == 'master' }}
+        uses: catalyst/catalyst-moodle-workflows/.github/plugin/release@main
+        with:
+          plugin_name: ${{ inputs.plugin_name }}
+          moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}


### PR DESCRIPTION
Pinned to master currently, if 4.1 comes out, 4.0 will need to be updated to the stable branch, and 4.1 pinned to master (most probably). This way we can ensure our plugins have some CI testing the latest Moodle version.

Relevant docs: 
- https://docs.moodle.org/dev/Moodle_4.0_release_notes#Server_requirements