### PR TITLE
feat: add skip duplication actions check to prevent dupe workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,24 @@ on:
         type: string
 
 jobs:
+  pre_job:
+   name: check if job needs to run
+   runs-on: ubuntu-latest
+   # Map a step output to a job output
+   outputs:
+     should_skip: ${{ steps.skip_check.outputs.should_skip }}
+   steps:
+     - id: skip_check
+       # docs: https://github.com/fkirc/skip-duplicate-actions#skip-concurrent-workflow-runs
+       uses: fkirc/skip-duplicate-actions@master
+       with:
+         # Do not trust previous successful runs
+         skip_after_successful_duplicate: false
+         # Ensure should_skip is true only if 2 concurrent workflows are working on the same files (content)
+         concurrent_skipping: 'same_content_newer'
   prepare_matrix:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     name: prepare test matrix
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -101,6 +118,7 @@ jobs:
   setup:
     name: ${{ matrix.moodle-branch }} - ${{ matrix.database }} - php ${{ matrix.php }} - ${{ needs.prepare_matrix.outputs.component }}
     needs: prepare_matrix
+    if: needs.pre_job.outputs.should_skip != 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_matrix.outputs.matrix) }}
@@ -156,7 +174,7 @@ jobs:
     # - MOODLE_XX_STABLE
     # - MOODLE_XXX_STABLE
     # - main
-    if: needs.prepare_matrix.outputs.release_required == 'true'
+    if: needs.pre_job.outputs.should_skip != 'true' && needs.prepare_matrix.outputs.release_required == 'true'
     runs-on: 'ubuntu-latest'
     steps:
       - run: |


### PR DESCRIPTION
This would typically occur when a workflow is triggered in a PR, which
will trigger a workflow for push and pull_request events each.

Resolves #31 