### PR TITLE
fix: publishable is now properly set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             )
           ) }}
 
-          echo '::set-output name=publishable::$publishable'
+          echo "::set-output name=publishable::$publishable"
       - name: Check out CI code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The issue was due to it being set to the literal name of the variable, not the value the variable held.

Resolves #42

As shown here, it seems to be passing the literal name of the variable instead of the value it held
https://github.com/catalyst/moodle-tool_abconfig/runs/7016097021?check_suite_focus=true#step:2:88