### PR TITLE
48 add configurable option for phpcs warnings as errors

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -1,6 +1,9 @@
 name: 'Plugin setup'
 description: 'Run plugin setup'
 inputs:
+  codechecker_max_warnings:
+    description: 'Sets the value for --max-warnings on the moodle-plugin-ci codechecker step. Defaults to -1 which means no limit.'
+    default: '-1'
   extra_php_extensions:
     description: 'List of additional php packages to install'
   extra_plugin_runners:
@@ -86,7 +89,7 @@ runs:
 
     - name: Run codechecker
       if: ${{ always() }}
-      run: moodle-plugin-ci codechecker
+      run: moodle-plugin-ci codechecker --max-warnings=${{ inputs.codechecker_max_warnings }}
       shell: bash
 
     - name: Run validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ name: ci
 on:
   workflow_call:
     inputs:
+      codechecker_max_warnings:
+        type: string
+        description: 'Sets the value for --max-warnings on the moodle-plugin-ci codechecker step. Defaults to -1 which means no limit.'
+        default: '-1'
       extra_php_extensions:
         type: string
       extra_plugin_runners:
@@ -161,6 +165,7 @@ jobs:
       - name: Run plugin setup
         uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
         with:
+          codechecker_max_warnings: ${{ inputs.codechecker_max_warnings }}
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/README.md
+++ b/README.md
@@ -72,17 +72,18 @@ You can add extra options to disable checks that you might not want, or to add a
 
 Below lists the available inputs which are _all optional_:
 
-| Inputs               | Description                                |
-|----------------------|--------------------------------------------|
-| extra_plugin_runners | Command to install additional dependencies |
-| disable_behat        | Set `true` to disable behat tests.         |
-| disable_phplint      | Set `true` to disable phplint tests.       |
-| disable_phpunit      | Set `true` to disable phpunit tests.       |
-| disable_grunt        | Set `true` to disable grunt.               |
-| disable_master       | If `true`, this will skip testing against moodle/master branch |
-| disable_release      | If `true`, this will skip the release job |
-| release_branches     | Name of the non-standardly named branch which should run the release job |
-| moodle_branches      | Specify the MOODLE_XX_STABLE branch you specifically want to test against. This is _not_ recommended, and instead you should configuring a supported range. |
+| Inputs                   | Description                                |
+|--------------------------|--------------------------------------------|
+| codechecker_max_warnings | To fail on warnings, set this to 0         |
+| extra_plugin_runners     | Command to install more dependencies       |
+| disable_behat            | Set `true` to disable behat tests.         |
+| disable_phplint          | Set `true` to disable phplint tests.       |
+| disable_phpunit          | Set `true` to disable phpunit tests.       |
+| disable_grunt            | Set `true` to disable grunt.               |
+| disable_master           | If `true`, this will skip testing against moodle/master branch |
+| disable_release          | If `true`, this will skip the release job |
+| release_branches         | Name of the non-standardly named branch which should run the release job |
+| moodle_branches          | Specify the MOODLE_XX_STABLE branch you specifically want to test against. This is _not_ recommended, and instead you should configuring a supported range. |
 
 ### Add CI badge
 


### PR DESCRIPTION
So I've tested this on the dataflows repository in particular:

No option set, expecting the defaults to PASS on codechecker WARNINGS:
https://github.com/catalyst/moodle-tool_dataflows/runs/7296148234?check_suite_focus=true#step:3:1935

New option `codechecker_max_warnings` set, expecting it to FAIL on codechecker WARNINGS
https://github.com/catalyst/moodle-tool_dataflows/runs/7296253313?check_suite_focus=true#step:3:1916

As expected, the CI fails after performing the codechecker run, when set as `codechecker_max_warnings: 0`, but passes otherwise.

Resolves #48 

Tested using a commit that references the current branch of this repo: 
https://github.com/catalyst/catalyst-moodle-workflows/pull/50/commits/58c998fa080af1bf3f4d1aa900c23712e447639b