### PR TITLE
Add options to the matrix allowing to specify database versions.

### DIFF
--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -1,24 +1,24 @@
 include:
   # Versions 3.3 - 3.4 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_33_STABLE', php: '7.1', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_34_STABLE', php: '7.1', node: '14.15', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_33_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_34_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # Test all combinations for version 3.5 (as it is LTS).
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # Versions 3.6 - 3.8 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_36_STABLE', php: '7.1', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_37_STABLE', php: '7.2', node: '14.15', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_38_STABLE', php: '7.3', node: '14.15', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_36_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_37_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_38_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
   # Also test all variants of 3.9 (LTS).
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '14.15', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '14.15', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # 3.10 - 4.00 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_310_STABLE', php: '7.2', node: '14.15', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '14.15', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '14.15', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_310_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # Always include master (issue #18) - disable-able by config by setting 'disable_master' to true
-  - {moodle-branch: 'master', php: '7.4', node: '14.15', database: 'pgsql'}
+  - {moodle-branch: 'master', php: '7.4', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql'}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     services:
       postgres:
-        image: postgres:10
+        image: "postgres:${{ matrix.pgsql-ver }}"
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -150,7 +150,7 @@ jobs:
         ports:
           - 5432:5432
       mariadb:
-        image: mariadb:10.5
+        image: "mariadb:${{ matrix.mariadb-ver }}"
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"


### PR DESCRIPTION
This change will allow using a recommended version of the database depending
on the requirements in each particular moodle branch.

This is mostly related to Moodle master (ver 401 at this time) requirement to use Postgres 12 or newer.

Each row in the matrix must include the version for both mariadb and postgresql. Although each test only uses one DB service, 
 both DB services will run and for this reason the unneeded DB version could not be skipped.

There was an idea to provide only the version for the DB, which will be tested in the particular test.
However, Git action syntax does not allow certain things like using conditions to generate the default version for the database, which was not specified in the matrix.