### PR TITLE
Fix and improved phpdocs check, reduced some log noise, add better options for future CI tweaking

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -57,22 +57,38 @@ runs:
 
     - name: Initialise moodle-plugin-ci
       run: |
-        composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+        # Initialise moodle-plugin-ci (install via composer)
+        echo "::group::Initialise moodle-plugin-ci"
+
+        composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci m-ci ^3
         # Add dirs to $PATH
-        echo $(cd ci/bin; pwd) >> $GITHUB_PATH
-        echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+        echo $(cd m-ci/bin; pwd) >> $GITHUB_PATH
+        echo $(cd m-ci/vendor/bin; pwd) >> $GITHUB_PATH
         # PHPUnit depends on en_AU.UTF-8 locale
         sudo locale-gen en_AU.UTF-8
+
+        echo "::endgroup::"
       shell: bash
 
     - name: Install dependencies
       if: ${{ inputs.extra_plugin_runners }}
       run: |
+        # Install dependencies
+        echo "::group::Install dependencies"
+
         ${{ inputs.extra_plugin_runners }}
+
+        echo "::endgroup::"
       shell: bash
 
     - name: Install Moodle
-      run:  moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1
+      run: |
+        # Install moodle commands
+        echo "::group::Moodle install output"
+
+        moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1
+
+        echo "::endgroup::"
       shell: bash
       env:
         DB: ${{ matrix.database }}
@@ -142,7 +158,40 @@ runs:
       shell: bash
 
     - name: Moodle PHPDoc Checker
-      if: ${{ always() }}
+      if: ${{ always() && inputs.highest_moodle_branch == matrix.moodle-branch }}
       # Run this check and only fail CI if it's on 4.0+ / master
-      run: moodle-plugin-ci phpdoc || !(matrix.moodle-branch == 'MOODLE_400_STABLE' || matrix.moodle-branch == 'master')
+      run: |
+        # phpdoc checks
+
+        # Don't stop on faiures
+        set +e
+
+        # Note this block whilst large, was made so that it can be pasted locally if needed and isn't CI specific
+        # Disclaimer: you'll need to adjust the main command but otherwise the handling of output remains the same.
+        output=`GITHUB_PATH=$GITHUB_PATH moodle-plugin-ci phpdoc`
+        haserrors=$?
+
+        # No errors? Print and return.
+        if [[ $haserrors -eq 0 ]]; then
+          echo "phpdoc checks - OK"
+          exit 0
+        fi
+
+        # Skip incorrect errors/warnings and retain the relevant lines.
+        output=`echo "$output" | grep -v 'Class ( is not documented' | grep -v 'Could not connect to debugging client.'`
+        output=`echo "$output" | grep -B1 'Line'`
+
+        # Filter out github actions paths from the output. It should only
+        # show the path relevant to the files in the plugin repo.
+        # For example:
+        # from /home/runner/work/moodle-tool_dataflows/moodle-tool_dataflows/moodle/admin/tool/dataflows/db/upgrade.php
+        # to   db/upgrade.php at best,
+        # or   admin/tool/dataflows/db/upgrade.php
+        currentdir=$(pwd)
+        if [[ "$output" ]]; then
+          echo "$output" | sed -e "s,$currentdir/,,g" | sed -e "s,^moodle/,,g" | tee $GITHUB_STEP_SUMMARY
+          exit 1
+        fi
+
+        echo "phpdoc checks - OK"
       shell: bash

--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: 'Option to disable behat tests'
   disable_mustache:
     description: 'Option to disable mustache tests'
+  disable_phpdoc:
+    description: 'Option to disable phpdoc tests'
   disable_phplint:
     description: 'Option to disable phplint tests'
   disable_phpunit:
@@ -158,7 +160,7 @@ runs:
       shell: bash
 
     - name: Moodle PHPDoc Checker
-      if: ${{ always() && inputs.highest_moodle_branch == matrix.moodle-branch }}
+      if: ${{ always() && inputs.disable_phpdoc != 'true' && inputs.highest_moodle_branch == matrix.moodle-branch }}
       # Run this check and only fail CI if it's on 4.0+ / master
       run: |
         # phpdoc checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ name: ci
 on:
   workflow_call:
     inputs:
+      internal_workflow_branch:
+        type: string
+        description: 'Sets the branch the reusable workflow calls reusable workflow actions with'
+        default: '64-fix-phpdoc-checks'
+        # default: 'main'
       codechecker_max_warnings:
         type: string
         description: 'Sets the value for --max-warnings on the moodle-plugin-ci codechecker step. Defaults to -1 which means no limit.'
@@ -90,12 +95,13 @@ jobs:
           ) }}
 
           echo "::set-output name=publishable::$publishable"
+      - uses: actions/checkout@v3
       - name: Check out CI code
         uses: actions/checkout@v2
         with:
           path: ci
           repository: catalyst/catalyst-moodle-workflows
-          ref: main
+          ref: ${{ inputs.internal_workflow_branch }}
           token: ${{ github.token }}
       - name: Check out plugin code
         uses: actions/checkout@v2
@@ -167,8 +173,15 @@ jobs:
           --health-timeout 5s
           --health-retries 3
     steps:
+      - name: Check out CI code
+        uses: actions/checkout@v2
+        with:
+          path: ci
+          repository: catalyst/catalyst-moodle-workflows
+          ref: ${{ inputs.internal_workflow_branch }}
+          token: ${{ github.token }}
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./ci/.github/plugin/setup
         with:
           codechecker_max_warnings: ${{ inputs.codechecker_max_warnings }}
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
@@ -202,9 +215,17 @@ jobs:
         if: ${{ env.SECRET_TO_CHECK != '' }}
         run: echo "::set-output name=has-secrets::true"
 
+      - name: Check out CI code
+        uses: actions/checkout@v2
+        with:
+          path: ci
+          repository: catalyst/catalyst-moodle-workflows
+          ref: ${{ inputs.internal_workflow_branch }}
+          token: ${{ github.token }}
+
       - name: Run plugin release
         if: steps.check-secrets.outputs.has-secrets != ''
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/release@main
+        uses: ./ci/.github/plugin/release
         with:
           plugin_name: ${{ needs.prepare_matrix.outputs.component }}
           moodle_org_token: ${{ secrets.moodle_org_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
       internal_workflow_branch:
         type: string
         description: 'Sets the branch the reusable workflow calls reusable workflow actions with'
-        default: '64-fix-phpdoc-checks'
-        # default: 'main'
+        default: 'main'
       codechecker_max_warnings:
         type: string
         description: 'Sets the value for --max-warnings on the moodle-plugin-ci codechecker step. Defaults to -1 which means no limit.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ on:
         type: boolean
       disable_phplint:
         type: boolean
+      disable_phpdoc:
+        type: boolean
+        description: 'If true, this will skip testing phpdocs'
+        default: false
       disable_phpunit:
         type: boolean
       disable_grunt:
@@ -189,6 +193,7 @@ jobs:
           disable_behat:    ${{ inputs.disable_behat }}
           disable_grunt:    ${{ inputs.disable_grunt }}
           disable_mustache: ${{ inputs.disable_mustache }}
+          disable_phpdoc:   ${{ inputs.disable_phpdoc }}
           disable_phplint:  ${{ inputs.disable_phplint }}
           disable_phpunit:  ${{ inputs.disable_phpunit }}
           enable_phpmd:     ${{ inputs.enable_phpmd }}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Below lists the available inputs which are _all optional_:
 | codechecker_max_warnings | To fail on warnings, set this to 0         |
 | extra_plugin_runners     | Command to install more dependencies       |
 | disable_behat            | Set `true` to disable behat tests.         |
+| disable_phpdoc           | Set `true` to disable phpdoc tests.       |
 | disable_phplint          | Set `true` to disable phplint tests.       |
 | disable_phpunit          | Set `true` to disable phpunit tests.       |
 | disable_grunt            | Set `true` to disable grunt.               |


### PR DESCRIPTION
Resolves #63 
Resolves #64 
Resolves #62 

Tests performed for confirmation:

https://github.com/catalyst/moodle-tool_dataflows/runs/7644515755?check_suite_focus=true#step:4:856
- Moodle install is collapsed (confirms noise reduced, grouping POC works)
- phpdoc checks are outputting as expected, reduced noise, relevant paths to file and is actually working

Note that this was tested with everything pointed to "main" (reusable workflow) by default, but overriden using a custom branch option: https://github.com/catalyst/moodle-tool_dataflows/pull/396/files#r936206729