### PR TITLE
[#103] feat: add MOODLE_402_STABLE to the test matrix

### DIFF
--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -1,7 +1,9 @@
 include:
   # Always include master (issue #18) - disable-able by config by setting 'disable_master' to true
-  - {moodle-branch: 'master', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql'}
+  - {moodle-branch: 'master', php: '8.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql'}
   # Test all variants of 4.2.
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql' }
   - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql' }
   # Test all variants of 4.1 (LTS).

--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -1,6 +1,9 @@
 include:
   # Always include master (issue #18) - disable-able by config by setting 'disable_master' to true
   - {moodle-branch: 'master', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql'}
+  # Test all variants of 4.2.
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql' }
   # Test all variants of 4.1 (LTS).
   - { moodle-branch: 'MOODLE_401_STABLE', php: '7.4', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_401_STABLE', php: '7.4', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql' }

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Each plugin should have a measurable range of versions supported. It's recommend
 
 ```php
 # version.php
-$plugin->supported = [35, 401];
+$plugin->supported = [35, 402];
 ```
-This example will run a matrix of tests from `MOODLE_35_STABLE` to `MOODLE_401_STABLE` - [see full test matrix here](.github/actions/matrix/matrix_includes.yml).
+This example will run a matrix of tests from `MOODLE_35_STABLE` to `MOODLE_402_STABLE` - [see full test matrix here](.github/actions/matrix/matrix_includes.yml).
 
 Any number _greater_ than the [latest available stable branch](https://github.com/moodle/moodle/branches/active) will automatically include the [master branch](https://github.com/moodle/moodle/tree/master) for testing
 


### PR DESCRIPTION
Configuration based on current master values. Notably dropped php 7.4 support for php 8.0

Resolves #103
