### PR TITLE
Update CI to use fetch-depth of 0 when publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           # Needed for 'changed-files' actions (alternatively could be a fixed
           # large number but may cause issues if limited).
-          fetch-depth: ${{ ((contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true')) && 0 || 2 }}
+          fetch-depth: ${{ (contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true') && 0 || 2 }}
           path: plugin
           submodules: true
       - name: Check if release is required (version.php changes)


### PR DESCRIPTION
**Description:** We are experiencing the following error in the GitHub Action for [mod_scormremote](https://github.com/catalyst/moodle-mod_scormremote/actions/runs/9477489114/job/26169615367). 

```
Warning: Unable to locate the previous sha: 37eed5f223c5d48a8a34566aef4faa4a254a212e
Warning: You seem to be missing 'fetch-depth: 0' or 'fetch-depth: 2'. See https://github.com/tj-actions/changed-files#usage
Error: Process completed with exit code 1.
```

The issue appears to be occurring due to this step/line of `CI.yml` [here](https://github.com/catalyst/catalyst-moodle-workflows/blob/main/.github/workflows/ci.yml#L128)

```
- name: Check out plugin code
      uses: actions/checkout@v3
      with:
        # Needed for 'changed-files' actions (alternatively could be a fixed
        # large number but may cause issues if limited).
---->   fetch-depth: ${{ ((contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true')) && 0 || 2 }}
        path: plugin
        submodules: true
```

Currently, the `fetch-depth` conditional is not being evaluated correctly. It uses a [ternary operator](https://docs.github.com/en/actions/learn-github-actions/expressions#example) and so if both `contains(github.event_name, 'push')` and `steps.check-branch.outputs.publishable == 'true'` are true, it should return `0`. However, it is returning `2` as seen in the [debug logs](https://github.com/catalyst/moodle-mod_scormremote/actions/runs/9477489114/job/26213485337#step:5:9) below:

```
##[debug]Evaluating: ((contains(github.event_name, 'push') && (steps.check-branch.outputs.publishable == 'true') && 0) || 2)
##[debug]Evaluating Or:
##[debug]..Evaluating And:
##[debug]....Evaluating contains:
##[debug]......Evaluating Index:
##[debug]........Evaluating github:
##[debug]........=> Object
##[debug]........Evaluating String:
##[debug]........=> 'event_name'
##[debug]......=> 'push'
##[debug]......Evaluating String:
##[debug]......=> 'push'
##[debug]....=> true
##[debug]....Evaluating Equal:
##[debug]......Evaluating Index:
##[debug]........Evaluating Index:
##[debug]..........Evaluating Index:
##[debug]............Evaluating steps:
##[debug]............=> Object
##[debug]............Evaluating String:
##[debug]............=> 'check-branch'
##[debug]..........=> Object
##[debug]..........Evaluating String:
##[debug]..........=> 'outputs'
##[debug]........=> Object
##[debug]........Evaluating String:
##[debug]........=> 'publishable'
##[debug]......=> 'true'
##[debug]......Evaluating String:
##[debug]......=> 'true'
##[debug]....=> true
##[debug]....Evaluating Number:
##[debug]....=> 0
##[debug]..=> 0
##[debug]..Evaluating Number:
##[debug]..=> 2
##[debug]=> 2
##[debug]Expanded: ((contains('push', 'push') && ('true' == 'true') && 0) || 2)
##[debug]Result: 2
```

It is altering the conditional by moving the closing brace to surround the `0` as well so that the only possible result to return is `2`. This means that this step is only fetching the latest two commits. In the case of `mod_scormremote`, fetching only the last two commits is not enough to find previous SHA `37eed5f`
![image](https://github.com/catalyst/catalyst-moodle-workflows/assets/65814885/eaa95530-91ae-4ec4-9ff8-68a0a0c094ee)

Note that setting `fetch-depth` to `0` is recommended [here](https://github.com/tj-actions/changed-files/tree/main?tab=readme-ov-file#on-push-%EF%B8%8F) 

