### PR TITLE
issue #116: fix fetch-depth ternary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           # Needed for 'changed-files' actions (alternatively could be a fixed
           # large number but may cause issues if limited).
-          fetch-depth: ${{ ((contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true')) && 0 || 2 }}
+          fetch-depth: ${{ !((contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true')) && 2 || 0 }}
           path: plugin
           submodules: true
       - name: Check if release is required (version.php changes)


### PR DESCRIPTION
**Description:** There is an issue with the 'ternary' operators in GitHub Actions outlined in this [discussion](https://github.com/orgs/community/discussions/75928#discussioncomment-8628993):

> There seems to be a way because there is "ternary like" operator in Github actions https://docs.github.com/en/actions/learn-github-actions/expressions#example . One thing to watch for is that "true value" (one after &&) need to be "truthy" to work as expected
> ```${{ github.event_name == 'release' && github.ref || inputs.release_ref }}
>${{ github.event_name == 'release' && github.ref || inputs.release_ref }}
>```

This [article](https://7tonshark.com/posts/github-actions-ternary-operator/#navigating-boolean-values) also describes the same issue as above and outlines the solution that is used in this PR.

---
**Solution:**

We flip the condition so that the value to use if true (second operand) is truthy

```
fetch-depth: ${{ !((contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true')) && 2 || 0 }}
```

