### PR TITLE
issue #116: use fixed fetch-depth value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           # Needed for 'changed-files' actions (alternatively could be a fixed
           # large number but may cause issues if limited).
-          fetch-depth: ${{ !((contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true')) && 2 || 0 }}
+          fetch-depth: 20
           path: plugin
           submodules: true
       - name: Check if release is required (version.php changes)


### PR DESCRIPTION
**Description:** The previous fix in #117 for Issue #116 did not work - the ternary was still evaluated incorrectly. Instead of being evaluated to 2, it was evaluating to true:

```
(success() && contains(github.event_name, 'push') && (steps.check-branch.outputs.publishable == 'true'))
```

Instead of using a ternary, we now use a fixed number (20) for fetch-depth.