### PR TITLE
[#121] Switch to lower nvm version

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -63,6 +63,12 @@ runs:
         composer self-update ${{ steps.install-composer1.outputs.COMPOSER_VERSION }}
       shell: bash
 
+    - name: Install specific NVM version
+      run: |
+        # Install nvm v0.39.7 (temp workaround for issue https://github.com/moodlehq/moodle-plugin-ci/issues/309).
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+        echo nvm -v
+      shell: bash
     - name: Initialise moodle-plugin-ci
       run: |
         # Initialise moodle-plugin-ci (install via composer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       internal_workflow_branch:
         type: string
         description: 'Sets the branch the reusable workflow calls reusable workflow actions with'
-        default: 'main'
+        default: 'nvm-workaround'
       codechecker_max_warnings:
         type: string
         description: 'Sets the value for --max-warnings on the moodle-plugin-ci codechecker step. Defaults to -1 which means no limit.'

--- a/.github/workflows/group-310-plus-ci.yml
+++ b/.github/workflows/group-310-plus-ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-310-plus-release.yml
+++ b/.github/workflows/group-310-plus-release.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-311-plus-ci.yml
+++ b/.github/workflows/group-311-plus-ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-311-plus-release.yml
+++ b/.github/workflows/group-311-plus-release.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-33-plus-ci.yml
+++ b/.github/workflows/group-33-plus-ci.yml
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-33-plus-release.yml
+++ b/.github/workflows/group-33-plus-release.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-33-to-38-ci.yml
+++ b/.github/workflows/group-33-to-38-ci.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-33-to-38-release.yml
+++ b/.github/workflows/group-33-to-38-release.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-33-to-39-ci.yml
+++ b/.github/workflows/group-33-to-39-ci.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-33-to-39-release.yml
+++ b/.github/workflows/group-33-to-39-release.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-34-plus-ci.yml
+++ b/.github/workflows/group-34-plus-ci.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-34-plus-release.yml
+++ b/.github/workflows/group-34-plus-release.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-34-to-38-ci.yml
+++ b/.github/workflows/group-34-to-38-ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-34-to-39-ci.yml
+++ b/.github/workflows/group-34-to-39-ci.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-35-plus-ci.yml
+++ b/.github/workflows/group-35-plus-ci.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-35-plus-release.yml
+++ b/.github/workflows/group-35-plus-release.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-35-to-310-ci.yml
+++ b/.github/workflows/group-35-to-310-ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-35-to-311-ci.yml
+++ b/.github/workflows/group-35-to-311-ci.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-35-to-39-ci.yml
+++ b/.github/workflows/group-35-to-39-ci.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-35-to-39-release.yml
+++ b/.github/workflows/group-35-to-39-release.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-36-plus-ci.yml
+++ b/.github/workflows/group-36-plus-ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-36-plus-release.yml
+++ b/.github/workflows/group-36-plus-release.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-37-plus-ci.yml
+++ b/.github/workflows/group-37-plus-ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-37-plus-release.yml
+++ b/.github/workflows/group-37-plus-release.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-38-plus-ci.yml
+++ b/.github/workflows/group-38-plus-ci.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-38-plus-release.yml
+++ b/.github/workflows/group-38-plus-release.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-39-plus-ci.yml
+++ b/.github/workflows/group-39-plus-ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-39-plus-release.yml
+++ b/.github/workflows/group-39-plus-release.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/group-40-plus-ci.yml
+++ b/.github/workflows/group-40-plus-ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ././../plugin/setup/action.yml
         with:
           extra_php_extensions: ${{ inputs.extra_php_extensions }}
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}

--- a/.github/workflows/group-40-plus-release.yml
+++ b/.github/workflows/group-40-plus-release.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/moodle-311-release.yml
+++ b/.github/workflows/moodle-311-release.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}

--- a/.github/workflows/moodle-39-release.yml
+++ b/.github/workflows/moodle-39-release.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Run plugin setup
-        uses: catalyst/catalyst-moodle-workflows/.github/plugin/setup@main
+        uses: ./../plugin/setup/action.yml
         with:
           extra_plugin_runners: ${{ inputs.extra_plugin_runners }}
           disable_behat: ${{ inputs.disable_behat }}


### PR DESCRIPTION
- Closes #121 
- Closes #123 (as a necessity to get this to test properly on a branch that is not `main`)

It has been over a week since the latest nvm 0.40 started breaking pipelines.
While it would be ideal to wait, we can't wait forever.
I don't see any issue downgrading, this this isn't downgrading node just downgrading the version manager.

Using https://github.com/catalyst/moodle-mod_hvp/pull/58 as the test to confirm the updated branch works