### PR TITLE
Update node from 14.15 to 20.11

### DIFF
--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -2,34 +2,34 @@ include:
   # Always include main (issue #18) - disable-able by config by setting 'disable_master' to true
   - {moodle-branch: 'main', php: '8.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql'}
   # Test all variants of 4.4.
-  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.3', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.3', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
-  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.1', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.1', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.3', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.3', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.1', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_404_STABLE', php: '8.1', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
   # Test all variants of 4.3.
-  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.2', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.2', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
-  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.2', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.2', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_403_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
   # Test all variants of 4.2.
-  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.1', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.1', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
-  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.1', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.1', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_402_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }
   # Test all variants of 4.1 (LTS).
-  - { moodle-branch: 'MOODLE_401_STABLE', php: '7.4', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_401_STABLE', php: '7.4', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql' }
-  - { moodle-branch: 'MOODLE_401_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_401_STABLE', php: '8.0', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_401_STABLE', php: '7.4', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '12', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_401_STABLE', php: '7.4', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_401_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '12', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_401_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql' }
   # 3.10 - 4.00 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_310_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_310_STABLE', php: '7.2', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # Also test all variants of 3.9 (LTS).
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # Versions 3.6 - 3.8 are not LTS, so only test a single combo for each.
   - {moodle-branch: 'MOODLE_38_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
   - {moodle-branch: 'MOODLE_37_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}


### PR DESCRIPTION
**Description:** This updates node from 14.15 to  20.11.

We are getting errors during workflows due to wrong node version:

In `MOODLE_39_STABLE` workflow
```
    ERR  npm WARN notsup Unsupported engine for grunt@1.6.1: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: grunt@1.6.1
```

In `MOODLE_401_STABLE` workflow
```
    ERR  npm WARN notsup Unsupported engine for stylelint-csstree-validator@3.0.0: wanted: {"node":"^14.13.0 || >=15.0.0","npm":">=7.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: stylelint-csstree-validator@3.0.0
```

In `MOODLE_402_STABLE` and `MOODLE_403_STABLE` workflow
```
    ERR  npm WARN notsup Unsupported engine for eslint@8.57.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint@8.57.1
    ERR  npm WARN notsup Unsupported engine for eslint-plugin-jsdoc@48.11.0: wanted: {"node":">=18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-plugin-jsdoc@48.11.0
    ERR  npm WARN notsup Unsupported engine for eslint-plugin-promise@6.0.0: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-plugin-promise@6.0.0
    ERR  npm WARN notsup Unsupported engine for grunt@1.6.1: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: grunt@1.6.1
    ERR  npm WARN notsup Unsupported engine for grunt-stylelint@0.19.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: grunt-stylelint@0.19.0
    ERR  npm WARN notsup Unsupported engine for stylelint-csstree-validator@3.0.0: wanted: {"node":"^14.13.0 || >=15.0.0","npm":">=7.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: stylelint-csstree-validator@3.0.0
    ERR  npm WARN notsup Unsupported engine for espree@9.6.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: espree@9.6.1
    ERR  npm WARN notsup Unsupported engine for @eslint/js@8.57.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @eslint/js@8.57.1
    ERR  npm WARN notsup Unsupported engine for eslint-scope@7.2.2: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-scope@7.2.2
    ERR  npm WARN notsup Unsupported engine for @eslint/eslintrc@2.1.4: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @eslint/eslintrc@2.1.4
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@3.4.3: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.4.3
    ERR  npm WARN notsup Unsupported engine for @eslint-community/eslint-utils@4.4.0: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @eslint-community/eslint-utils@4.4.0
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@3.4.3: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.4.3
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@3.4.3: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.4.3
    ERR  npm WARN notsup Unsupported engine for espree@10.2.0: wanted: {"node":"^18.18.0 || ^20.9.0 || >=21.1.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: espree@10.2.0
    ERR  npm WARN notsup Unsupported engine for synckit@0.9.2: wanted: {"node":"^14.18.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: synckit@0.9.2
    ERR  npm WARN notsup Unsupported engine for parse-imports@2.2.1: wanted: {"node":">= 18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: parse-imports@2.2.1
    ERR  npm WARN notsup Unsupported engine for @es-joy/jsdoccomment@0.46.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @es-joy/jsdoccomment@0.46.0
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@4.1.0: wanted: {"node":"^18.18.0 || ^20.9.0 || >=21.1.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@4.1.0
    ERR  npm WARN notsup Unsupported engine for @pkgr/core@0.1.1: wanted: {"node":"^12.20.0 || ^14.18.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @pkgr/core@0.1.1
    ERR  npm WARN notsup Unsupported engine for commander@11.0.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: commander@11.0.0
    ERR  npm WARN notsup Unsupported engine for minipass@7.1.2: wanted: {"node":">=16 || 14 >=14.17"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: minipass@7.1.2
    ERR  npm WARN notsup Unsupported engine for path-scurry@1.11.1: wanted: {"node":">=16 || 14 >=14.18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: path-scurry@1.11.1
    ERR  npm WARN notsup Unsupported engine for minimatch@9.0.5: wanted: {"node":">=16 || 14 >=14.17"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: minimatch@9.0.5
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.2 (node_modules/rollup/node_modules/fsevents):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN notsup Unsupported engine for chokidar@4.0.1: wanted: {"node":">= 14.16.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: chokidar@4.0.1
    ERR  npm WARN notsup Unsupported engine for readdirp@4.0.2: wanted: {"node":">= 14.16.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: readdirp@4.0.2
    ERR  npm WARN notsup Unsupported engine for tough-cookie@5.0.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: tough-cookie@5.0.0
    ERR  npm WARN notsup Unsupported engine for write-file-atomic@5.0.1: wanted: {"node":"^14.17.0 || ^16.13.0 || >=18.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: write-file-atomic@5.0.1
    ERR  npm WARN notsup Unsupported engine for supports-hyperlinks@3.1.0: wanted: {"node":">=14.18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: supports-hyperlinks@3.1.0
```

Did not change other Moodle versions as am unsure if they will also experience these errors.