### PR TITLE
Update node version for main Moodle branch from 14.15 to 20.11

### DIFF
--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -1,6 +1,6 @@
 include:
   # Always include main (issue #18) - disable-able by config by setting 'disable_master' to true
-  - {moodle-branch: 'main', php: '8.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql'}
+  - {moodle-branch: 'main', php: '8.1', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '13', database: 'pgsql'}
   # Test all variants of 4.4.
   - { moodle-branch: 'MOODLE_404_STABLE', php: '8.3', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_404_STABLE', php: '8.3', node: '20.11', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }


### PR DESCRIPTION
**Description:** This updates the node version for the main Moodle branch. This is failing in the run for the tool_advancedreplace plugin which supports the latest Moodle:

https://github.com/catalyst/moodle-tool_advancedreplace/actions/runs/11284610848/job/31386088221?pr=38

```
    ERR  npm WARN notsup Unsupported engine for commander@12.1.0: wanted: {"node":">=18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: commander@12.1.0
    ERR  npm WARN notsup Unsupported engine for eslint@8.57.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint@8.57.1
    ERR  npm WARN notsup Unsupported engine for eslint-plugin-jsdoc@48.11.0: wanted: {"node":">=18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-plugin-jsdoc@48.11.0
    ERR  npm WARN notsup Unsupported engine for eslint-plugin-promise@6.0.0: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-plugin-promise@6.0.0
    ERR  npm WARN notsup Unsupported engine for grunt@1.6.1: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: grunt@1.6.1
    ERR  npm WARN notsup Unsupported engine for grunt-stylelint@0.19.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: grunt-stylelint@0.19.0
    ERR  npm WARN notsup Unsupported engine for inquirer@9.3.7: wanted: {"node":">=18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: inquirer@9.3.7
    ERR  npm WARN notsup Unsupported engine for stylelint-csstree-validator@3.0.0: wanted: {"node":"^14.13.0 || >=15.0.0","npm":">=7.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: stylelint-csstree-validator@3.0.0
    ERR  npm WARN notsup Unsupported engine for espree@9.6.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: espree@9.6.1
    ERR  npm WARN notsup Unsupported engine for @eslint/js@8.57.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @eslint/js@8.57.1
    ERR  npm WARN notsup Unsupported engine for eslint-scope@7.2.2: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-scope@7.2.2
    ERR  npm WARN notsup Unsupported engine for @eslint/eslintrc@2.1.4: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @eslint/eslintrc@2.1.4
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@3.4.3: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.4.3
    ERR  npm WARN notsup Unsupported engine for @eslint-community/eslint-utils@4.4.0: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @eslint-community/eslint-utils@4.4.0
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@3.4.3: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.4.3
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@3.4.3: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.4.3
    ERR  npm WARN notsup Unsupported engine for espree@10.2.0: wanted: {"node":"^18.18.0 || ^20.9.0 || >=21.1.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: espree@10.2.0
    ERR  npm WARN notsup Unsupported engine for parse-imports@2.2.1: wanted: {"node":">= 18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: parse-imports@2.2.1
    ERR  npm WARN notsup Unsupported engine for synckit@0.9.2: wanted: {"node":"^14.18.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: synckit@0.9.2
    ERR  npm WARN notsup Unsupported engine for @es-joy/jsdoccomment@0.46.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @es-joy/jsdoccomment@0.46.0
    ERR  npm WARN notsup Unsupported engine for eslint-visitor-keys@4.1.0: wanted: {"node":"^18.18.0 || ^20.9.0 || >=21.1.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@4.1.0
    ERR  npm WARN notsup Unsupported engine for @pkgr/core@0.1.1: wanted: {"node":"^12.20.0 || ^14.18.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @pkgr/core@0.1.1
    ERR  npm WARN notsup Unsupported engine for commander@11.0.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: commander@11.0.0
    ERR  npm WARN notsup Unsupported engine for minipass@7.1.2: wanted: {"node":">=16 || 14 >=14.17"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: minipass@7.1.2
    ERR  npm WARN notsup Unsupported engine for minimatch@9.0.5: wanted: {"node":">=16 || 14 >=14.17"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: minimatch@9.0.5
    ERR  npm WARN notsup Unsupported engine for path-scurry@1.11.1: wanted: {"node":">=16 || 14 >=14.18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: path-scurry@1.11.1
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.2 (node_modules/rollup/node_modules/fsevents):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN notsup Unsupported engine for mute-stream@1.0.0: wanted: {"node":"^14.17.0 || ^16.13.0 || >=18.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: mute-stream@1.0.0
    ERR  npm WARN notsup Unsupported engine for yoctocolors-cjs@2.1.2: wanted: {"node":">=18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: yoctocolors-cjs@2.1.2
    ERR  npm WARN notsup Unsupported engine for @inquirer/figures@1.0.7: wanted: {"node":">=18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: @inquirer/figures@1.0.7
    ERR  npm WARN notsup Unsupported engine for chokidar@4.0.1: wanted: {"node":">= 14.16.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: chokidar@4.0.1
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-win32-x64@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-win32-x64):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-win32-x64@2.4.1: wanted {"os":"win32","arch":"x64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-win32-ia32@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-win32-ia32):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-win32-ia32@2.4.1: wanted {"os":"win32","arch":"ia32"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-darwin-x64@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-darwin-x64):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-darwin-x64@2.4.1: wanted {"os":"darwin","arch":"x64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-freebsd-x64@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-freebsd-x64):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-freebsd-x64@2.4.1: wanted {"os":"freebsd","arch":"x64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-win32-arm64@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-win32-arm64):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-win32-arm64@2.4.1: wanted {"os":"win32","arch":"arm64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-darwin-arm64@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-darwin-arm64):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-darwin-arm64@2.4.1: wanted {"os":"darwin","arch":"arm64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-android-arm64@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-android-arm64):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-android-arm64@2.4.1: wanted {"os":"android","arch":"arm64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-linux-arm64-musl@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm64-musl):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-linux-arm64-musl@2.4.1: wanted {"os":"linux","arch":"arm64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-linux-arm64-glibc@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm64-glibc):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-linux-arm64-glibc@2.4.1: wanted {"os":"linux","arch":"arm64"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN optional SKIPPING OPTIONAL DEPENDENCY: @parcel/watcher-linux-arm-glibc@2.4.1 (node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm-glibc):
    ERR  npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for @parcel/watcher-linux-arm-glibc@2.4.1: wanted {"os":"linux","arch":"arm"} (current: {"os":"linux","arch":"x64"})
    ERR  npm WARN notsup Unsupported engine for readdirp@4.0.2: wanted: {"node":">= 14.16.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: readdirp@4.0.2
    ERR  npm WARN notsup Unsupported engine for tough-cookie@5.0.0: wanted: {"node":">=16"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: tough-cookie@5.0.0
    ERR  npm WARN notsup Unsupported engine for write-file-atomic@5.0.1: wanted: {"node":"^14.17.0 || ^16.13.0 || >=18.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: write-file-atomic@5.0.1
    ERR  npm WARN notsup Unsupported engine for supports-hyperlinks@3.1.0: wanted: {"node":">=14.18"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: supports-hyperlinks@3.1.0
    ERR  npm WARN notsup Unsupported engine for readable-stream@4.5.2: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"14.15.5","npm":"6.14.11"})
    ERR  npm WARN notsup Not compatible with your version of node/npm: readable-stream@4.5.2
    ERR  
    ERR  
    OUT  added 1210 packages from 816 contributors and audited 1222 packages in 24.142s
    OUT  
    OUT  172 packages are looking for funding
    OUT    run `npm fund` for details
    OUT  
    OUT  found 52 vulnerabilities (4 low, 7 moderate, 36 high, 5 critical)
    OUT    run `npm audit fix` to fix them, or `npm audit` for details
    OUT  
    RES  Command ran successfully
    RUN  npx grunt ignorefiles
    OUT  Fatal error: Node version not satisfied. Require >=20.11.0 <21.0.0-0, version installed: 14.15.5
```