### PR TITLE
Revert "[#121] Switch to lower nvm version"

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -63,11 +63,6 @@ runs:
         composer self-update ${{ steps.install-composer1.outputs.COMPOSER_VERSION }}
       shell: bash
 
-    - name: Install specific NVM version
-      run: |
-        # Install nvm v0.39.7 (temp workaround for issue https://github.com/moodlehq/moodle-plugin-ci/issues/309).
-        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-      shell: bash
     - name: Initialise moodle-plugin-ci
       run: |
         # Initialise moodle-plugin-ci (install via composer)


### PR DESCRIPTION
**Changes**
- This reverts commit b687e8e3a1c9b59ebab037a87945bbeabb2f0bc2.

This commit was only a temporary measure until the upstream `nvm` repository implemented a fix, see https://github.com/catalyst/catalyst-moodle-workflows/issues/121#issuecomment-2276992178

The upstream `nvm` fix has been in place for a couple of months, I think we are safe to switch back. We should switch back so that we get regular updates to the nvm script (e.g. in case there are fixed security vulnerabilities)

HQ has also fixed this upstream as well and theirs is working, so am confident this will not break anything.