### PR TITLE
Upgrade to moodle-plugin-ci ^4

### DIFF
--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -27,23 +27,13 @@ include:
   - { moodle-branch: 'MOODLE_401_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '12', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_401_STABLE', php: '8.0', node: '20.11', mariadb-ver: '10.5', pgsql-ver: '12', database: 'pgsql' }
   # 3.10 - 4.00 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_310_STABLE', php: '7.2', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_400_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_311_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_310_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
   # Also test all variants of 3.9 (LTS).
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.2', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.3', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  # Versions 3.6 - 3.8 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_38_STABLE', php: '7.3', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_37_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_36_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  # Test all combinations for version 3.5 (as it is LTS).
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
-  - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  # Versions 3.3 - 3.4 are not LTS, so only test a single combo for each.
-  - {moodle-branch: 'MOODLE_34_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
-  - {moodle-branch: 'MOODLE_33_STABLE', php: '7.1', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}
+  - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '16.20', mariadb-ver: '10.5', pgsql-ver: '10', database: 'pgsql'}
+  # Version 3.8 is the oldets branch supported and is not LTS, so only test a single combo.
+  - {moodle-branch: 'MOODLE_38_STABLE', php: '7.4', node: '14.15', mariadb-ver: '10.5', pgsql-ver: '10', database: 'mariadb'}

--- a/.github/actions/parse-version/script.php
+++ b/.github/actions/parse-version/script.php
@@ -60,7 +60,7 @@ $matrix = Yaml::parse($matrixYaml);
 
 // Version breakpoints are sourced from:
 // https://download.moodle.org/api/1.3/updates.php?format=json&version=0.0&branch=$lowestSupportedBranch
-$updates = json_decode(file_get_contents('https://download.moodle.org/api/1.3/updates.php?format=json&version=0.0&branch=3.3'), true);
+$updates = json_decode(file_get_contents('https://download.moodle.org/api/1.3/updates.php?format=json&version=0.0&branch=3.8'), true);
 $updates = $updates['updates']['core'] ?? [];
 
 $preparedMatrix = array_filter($matrix['include'], function($entry) use($plugin, $updates, $matrix) {

--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -68,7 +68,7 @@ runs:
         # Initialise moodle-plugin-ci (install via composer)
         echo "::group::Initialise moodle-plugin-ci"
 
-        composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci m-ci ^3
+        composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci m-ci ^4
         # Add dirs to $PATH
         echo $(cd m-ci/bin; pwd) >> $GITHUB_PATH
         echo $(cd m-ci/vendor/bin; pwd) >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ on:
       min_php:
         description: 'Specify the minimum version of PHP to test against. Will exclude workflows using older versions of PHP.'
         type: string
-        default: '7.1'
+        default: '7.4'
       ignore_paths:
         description: 'Specify custom paths for CI to ignore. Third party libraries are ignored by default.'
         type: string

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Below lists the available inputs which are _all optional_:
 | enable_phpmd             | If `true`, to enable phpmd                                                                                                                                                               |
 | release_branches         | Name of the non-standardly named branch which should run the release job                                                                                                                 |
 | moodle_branches          | Specify the MOODLE_XX_STABLE branch you specifically want to test against. This is _not_ recommended, and instead you should configuring a supported range.                              |
-| min_php                  | The minimum php version to test. Set this to support the minimum php version supported by the plugin. Defaults to '7.1', however more recent Moodle branches only test higher versions.  |
+| min_php                  | The minimum php version to test. Set this to support the minimum php version supported by the plugin. Defaults to '7.4', however more recent Moodle branches only test higher versions.  |
 | ignore_paths             | Specify custom paths for CI to ignore. Third party libraries are ignored by default. |
 
 ### Running with dependencies


### PR DESCRIPTION
Version 4.x of moodle-plugin-ci requires Moodle 3.8.3 or later, and PHP version 7.4 of higher.

Moodle 3.8 was released in 2019. It should be safe to drop this by now.