### PR TITLE
[#141] Add disable codechecker option

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -14,6 +14,8 @@ inputs:
     description: 'Option to disable mustache tests'
   disable_phpdoc:
     description: 'Option to disable phpdoc tests'
+  disable_phpcs:
+    description: 'Option to disable code standards (codechecker) tests'
   disable_phplint:
     description: 'Option to disable phplint tests'
   disable_phpunit:
@@ -117,7 +119,7 @@ runs:
       shell: bash
 
     - name: Run codechecker
-      if: ${{ always() }}
+      if: ${{ always() && inputs.disable_phpcs != 'true' }}
       run: moodle-plugin-ci codechecker --max-warnings=${{ inputs.codechecker_max_warnings }}
       shell: bash
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Below lists the available inputs which are _all optional_:
 | extra_plugin_runners     | Command to install more dependencies                                                                                                                                                     |
 | disable_behat            | Set `true` to disable behat tests.                                                                                                                                                       |
 | disable_phpdoc           | Set `true` to disable phpdoc tests.                                                                                                                                                      |
+| disable_phpcs            | Set `true` to disable phpcs (codechecker) tests.                                                                                                                                         |
 | disable_phplint          | Set `true` to disable phplint tests.                                                                                                                                                     |
 | disable_phpunit          | Set `true` to disable phpunit tests.                                                                                                                                                     |
 | disable_grunt            | Set `true` to disable grunt.                                                                                                                                                             |


### PR DESCRIPTION
Closes #141 

**Changes**
- Adds `disable_phpcs` option to align with the other `disable_*` options, which can be used to disable codechecker

**Testing**
- I've not gone through the effort of testing this as its a bit finicky to do on a separate repo, so I've just copied the others and am 95% sure it will work, but will know for sure once merged.