### PR TITLE
[#151] Apply core patches before plugin install

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -91,6 +91,15 @@ runs:
         echo "::endgroup::"
       shell: bash
 
+    - name: Install Core Patches
+      if: ${{ always() }}
+      # We should attempt to install a patch, and pass if there isnt one for the branch.
+      run: |
+        git config --global user.email "test@test.com"
+        git config --global user.name "Test"
+        ((test -f plugin/patch/${{ matrix.moodle-branch }}.diff && cd moodle && git am --whitespace=nowarn < ../plugin/patch/${{ matrix.moodle-branch }}.diff) || echo No patch found;)
+      shell: bash
+
     - name: Install Moodle
       run: |
         # Install moodle commands
@@ -103,15 +112,6 @@ runs:
       env:
         DB: ${{ matrix.database }}
         MOODLE_BRANCH: ${{ matrix.moodle-branch }}
-
-    - name: Install Core Patches
-      if: ${{ always() }}
-      # We should attempt to install a patch, and pass if there isnt one for the branch.
-      run: |
-        git config --global user.email "test@test.com"
-        git config --global user.name "Test"
-        ((test -f plugin/patch/${{ matrix.moodle-branch }}.diff && cd moodle && git am --whitespace=nowarn < ../plugin/patch/${{ matrix.moodle-branch }}.diff) || echo No patch found;)
-      shell: bash
 
     - name: Run phplint
       if: ${{ always() && inputs.disable_phplint != 'true' }}


### PR DESCRIPTION
Closes #151 

At the moment the core patches are applied _after_ plugin install, meaning things like the class cache, hooks, db install are not initialised properly.

I have not tested this directly as its difficult to test, but I will test it immediately after merging in https://github.com/catalyst/moodle-tool_emailutils/pull/104 as I believe that PR is affected by this issue