### PR TITLE
[#151] Clone moodle before apply core patches

### DIFF
--- a/.github/plugin/setup/action.yml
+++ b/.github/plugin/setup/action.yml
@@ -91,21 +91,38 @@ runs:
         echo "::endgroup::"
       shell: bash
 
+    - name: Clone Moodle
+      # Clone to a temporary directory
+      run: |
+        echo "::group::Moodle clone output"
+
+        git clone https://github.com/moodle/moodle.git --branch $MOODLE_BRANCH $GITHUB_WORKSPACE/moodletemp
+
+        echo "::endgroup::"
+      shell: bash
+      env:
+        DB: ${{ matrix.database }}
+        MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
     - name: Install Core Patches
       if: ${{ always() }}
-      # We should attempt to install a patch, and pass if there isnt one for the branch.
+      # Install core patches to moodle in temporary directory
       run: |
         git config --global user.email "test@test.com"
         git config --global user.name "Test"
-        ((test -f plugin/patch/${{ matrix.moodle-branch }}.diff && cd moodle && git am --whitespace=nowarn < ../plugin/patch/${{ matrix.moodle-branch }}.diff) || echo No patch found;)
+        ((test -f plugin/patch/${{ matrix.moodle-branch }}.diff && cd $GITHUB_WORKSPACE/moodletemp && git am --whitespace=nowarn < ../plugin/patch/${{ matrix.moodle-branch }}.diff) || echo No patch found;)
       shell: bash
 
-    - name: Install Moodle
+    - name: Install Moodle and Plugin
+      # Install moodle, but use our temporary directory to include any potential core patches that have been applied.
       run: |
         # Install moodle commands
         echo "::group::Moodle install output"
 
-        moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1
+        # This is a workaround for https://github.com/moodlehq/moodle-plugin-ci/issues/306 - we disable the git repository validation to allow folder cloning.
+        sed -i '/public function gitUrl($url)/{n; s/{/& return $url;/}' $GITHUB_WORKSPACE/m-ci/src/Validate.php
+
+        moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1 --repo $GITHUB_WORKSPACE/moodletemp
 
         echo "::endgroup::"
       shell: bash

--- a/README.md
+++ b/README.md
@@ -173,3 +173,19 @@ To fix this, you'll need to rebundle the relevant files, on the <ins>highest sup
 __NOTE:__ This may involve having a clean copy of Moodle and installing the plugin code to run the necessary commands to rebuild the _stale_ files.
 
 Grunt docs: https://docs.moodle.org/dev/Grunt#Running_grunt
+
+### Testing changes
+Changes can be tested by using another plugin repository that uses these workflows.
+
+Simply change the repository/branch it pulls from:
+
+```yml
+uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@my-custom-branch
+```
+
+and specify the same branch as a `with` parameter:
+
+```yml
+with:
+  internal_workflow_branch: 'my-custom-branch'
+```


### PR DESCRIPTION
Closes #151 

## Issue
Core patches need to be in the codebase before moodle install occurs.

There is a bit of a chicken and egg problem here since moodle plugin ci installs both moodle and the plugin at the same time, leaving no option for changes or core patches.

`moodle-plugin-ci` also only accepts git clone and not a local folder.

## Fix
I've updated it clones to a temporary directory and applies patches ontop of that.

Then it uses a little known feature of git - file cloning, i.e. `git clone /my/local/repo moodle` is perfectly valid.

The only issue is this is currently broken as Moodle plugin ci (incorrectly) rejects file repo urls https://github.com/moodlehq/moodle-plugin-ci/issues/306

So I have temporarily disabled this validation. At the end of the day its just validation, so I don't see much issue with turning it off in our specific case :)

It's definitely a hack but considering this issue has been open in upstream ci for 1.5 yrs now I don't want to wait on them.

## Testing

I tested this using https://github.com/catalyst/moodle-tool_emailutils/pull/104 which is temporarily pointing to this branch. Once this is merged, i'll switch it back to the `main` branch

<img width="1064" height="800" alt="image" src="https://github.com/user-attachments/assets/90f1120e-ed4f-4095-855d-ca6328f0571c" />
