### PR TITLE
Deploy based on version comparison against plugins directory

### DIFF
--- a/.github/plugin/release/action.yml
+++ b/.github/plugin/release/action.yml
@@ -13,7 +13,51 @@ runs:
       uses: actions/checkout@v2
       with:
         path: plugin
+    - name: Check if version is already deployed
+      # Instead of checking whether version.php changed in the triggering commit,
+      # we compare the local version against what is already on moodle.org.
+      # This means a version bump that initially failed CI will still deploy once
+      # CI goes green on a later commit, without needing to re-touch version.php.
+      id: version-check
+      env:
+        PLUGIN: ${{ inputs.plugin_name }}
+        ENDPOINT: https://moodle.org/webservice/rest/server.php
+        TOKEN: ${{ inputs.moodle_org_token }}
+      run: |
+        LOCAL_VERSION=$(grep -oP '\$plugin->version\s*=\s*\K[0-9]+' plugin/version.php)
+        echo "Local version.php version: ${LOCAL_VERSION}"
+
+        RESPONSE=$(curl -s "${ENDPOINT}" \
+          --data-urlencode "wstoken=${TOKEN}" \
+          --data-urlencode "wsfunction=local_plugins_get_plugin_versions" \
+          --data-urlencode "moodlewsrestformat=json" \
+          --data-urlencode "frankenstyle=${PLUGIN}")
+
+        # If the response isn't a JSON array (e.g. network error or auth failure),
+        # fall through and attempt deployment so we don't silently skip a real release.
+        if ! echo "${RESPONSE}" | jq -e 'type == "array"' > /dev/null 2>&1; then
+          echo "Could not query current versions from moodle.org — will attempt deployment anyway."
+          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Find the highest version number already deployed on this branch.
+        REMOTE_VERSION=$(echo "${RESPONSE}" | jq -r \
+          "[.[] | select(.vcsbranch == \"${GITHUB_REF_NAME}\")] | map(.version) | max // 0")
+
+        echo "Latest deployed version on branch ${GITHUB_REF_NAME}: ${REMOTE_VERSION}"
+
+        if [ "${LOCAL_VERSION}" -gt "${REMOTE_VERSION}" ]; then
+          echo "Local version ${LOCAL_VERSION} is newer — deploying."
+          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Version ${LOCAL_VERSION} is already deployed on branch ${GITHUB_REF_NAME}. Nothing to do."
+          echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash
+
     - name: Release at Moodle.org by calling the service function
+      if: steps.version-check.outputs.should_deploy == 'true'
       id: add-version
       env:
         PLUGIN: ${{ inputs.plugin_name }}
@@ -43,6 +87,7 @@ runs:
       shell: bash
 
     - name: Evaluate the response
+      if: steps.version-check.outputs.should_deploy == 'true'
       id: evaluate-response
       env:
         RESPONSE: ${{ steps.add-version.outputs.response }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
       lowest_php: ${{ steps.parse-version.outputs.lowest_php }}
       release_required: ${{ (
           contains(github.event_name, 'push') &&
-          steps.check-version.outputs.any_changed == 'true' &&
           steps.check-branch.outputs.publishable == 'true'
         ) }}
     steps:
@@ -135,20 +134,8 @@ jobs:
       - name: Check out plugin code
         uses: actions/checkout@v3
         with:
-          # Needed for 'changed-files' actions (alternatively could be a fixed
-          # large number but may cause issues if limited).
-          fetch-depth: 20
           path: plugin
           submodules: true
-      - name: Check if release is required (version.php changes)
-        if: contains(github.event_name, 'push') && steps.check-branch.outputs.publishable == 'true'
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
-        id: check-version
-        with:
-          path: plugin
-          files: |
-            version.php
-          since_last_remote_commit: "true"
       - name: Install PHP
         uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:


### PR DESCRIPTION
Previously a release was triggered only if version.php changed in the commit that triggered the CI run. This meant that if a version bump commit failed CI and was later fixed by a separate commit (without touching version.php again), no release would ever be triggered.

New behaviour:
- release_required is true for any push to a publishable branch
- The release action queries moodle.org for the highest version already deployed on this branch and compares it to the local version.php value
- Deploy only if local version > remote version (newer)
- Skip silently if already deployed (same or newer version on moodle.org)
- If moodle.org cannot be queried, fall through and attempt deploy anyway so real releases are never silently dropped