### PR TITLE
update moodle versions

### DIFF
--- a/.github/actions/matrix/matrix_includes.yml
+++ b/.github/actions/matrix/matrix_includes.yml
@@ -1,16 +1,19 @@
 include:
   # Always include main (issue #18) - disable-able by config by setting 'disable_master' to true
-  - {moodle-branch: 'main', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '15', database: 'pgsql'}
+  - {moodle-branch: 'main', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '16', database: 'pgsql'}
+  # Test all variants of 5.2
+  - { moodle-branch: 'MOODLE_502_STABLE', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '16', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_502_STABLE', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '16', database: 'pgsql' }
+  - { moodle-branch: 'MOODLE_502_STABLE', php: '8.3', node: '22', mariadb-ver: '10.11', pgsql-ver: '16', database: 'mariadb' }
+  - { moodle-branch: 'MOODLE_502_STABLE', php: '8.3', node: '22', mariadb-ver: '10.11', pgsql-ver: '16', database: 'pgsql' }
   # Test all variants of 5.1
   - { moodle-branch: 'MOODLE_501_STABLE', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '15', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_501_STABLE', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '15', database: 'pgsql' }
   - { moodle-branch: 'MOODLE_501_STABLE', php: '8.2', node: '22', mariadb-ver: '10.11', pgsql-ver: '15', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_501_STABLE', php: '8.2', node: '22', mariadb-ver: '10.11', pgsql-ver: '15', database: 'pgsql' }
-  # Test all variants of 5.0
+  # Test limited variants of 5.0
   - { moodle-branch: 'MOODLE_500_STABLE', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '14', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_500_STABLE', php: '8.4', node: '22', mariadb-ver: '10.11', pgsql-ver: '14', database: 'pgsql' }
-  - { moodle-branch: 'MOODLE_500_STABLE', php: '8.2', node: '22', mariadb-ver: '10.11', pgsql-ver: '14', database: 'mariadb' }
-  - { moodle-branch: 'MOODLE_500_STABLE', php: '8.2', node: '22', mariadb-ver: '10.11', pgsql-ver: '14', database: 'pgsql' }
   # Test all variants of 4.5. (LTS).
   - { moodle-branch: 'MOODLE_405_STABLE', php: '8.3', node: '22', mariadb-ver: '10.6', pgsql-ver: '13', database: 'mariadb' }
   - { moodle-branch: 'MOODLE_405_STABLE', php: '8.3', node: '22', mariadb-ver: '10.6', pgsql-ver: '13', database: 'pgsql' }


### PR DESCRIPTION
5.0 - only testing 1 php version, this is now out of active support
5.2 - adding it now its released.

Bumped pgsql to 16 as well, as this is required for 5.2+